### PR TITLE
Add dynamic symbol selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,6 +344,8 @@ test_message             → Connection test message
 | `SECRET_KEY` | Flask session key | Change in production | Generate secure key |
 | `API_KEY_PEPPER` | Encryption pepper | Change in production | Generate secure key |
 
+You can change the instrument directly from the dashboard using the **Symbol** field. Enter any valid trading symbol to resubscribe the live feed without restarting the server.
+
 ### **TBT Data Processing**
 - **High-Frequency Updates**: Handles 1000+ ticks per second efficiently
 - **Invalid Data Correction**: Automatically handles price=0.0 + quantity>0 anomalies

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -193,6 +193,12 @@
                     <input type="checkbox" class="toggle toggle-sm toggle-primary" id="lot-size-toggle" />
                 </label>
             </div>
+
+            <!-- Symbol Selector -->
+            <div class="form-control hidden md:block">
+                <input id="symbol-input" type="text" placeholder="NSE:SBIN-EQ" class="input input-xs input-bordered w-36" />
+            </div>
+            <button class="btn btn-primary btn-xs hidden md:inline-flex" id="symbol-btn">Set</button>
             
             <div class="dropdown dropdown-end">
                 <label tabindex="0" class="btn btn-ghost btn-circle">
@@ -1453,9 +1459,24 @@
         document.getElementById('lot-size-toggle').addEventListener('change', function() {
             displayLotSize = this.checked;
             console.log('🔄 Lot size display toggled:', displayLotSize ? 'ON' : 'OFF');
-            
+
             // Force refresh of the current DOM display
             refreshQuantityDisplays();
+        });
+
+        // Symbol update handler
+        document.getElementById('symbol-btn').addEventListener('click', function() {
+            const newSymbol = document.getElementById('symbol-input').value.trim();
+            if (!newSymbol) return;
+            fetch('/api/symbol', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ symbol: newSymbol })
+            }).then(r => r.json()).then(resp => {
+                if (resp.symbol) {
+                    document.getElementById('symbol-display').textContent = resp.symbol;
+                }
+            });
         });
         
         function refreshQuantityDisplays() {


### PR DESCRIPTION
## Summary
- let the app's websocket loop be addressable via `ws_loop`
- add `/api/symbol` endpoint for updating the traded symbol
- run websocket client on its own loop
- add symbol selector UI on the dashboard and JS handler
- document symbol switching capability in README

## Testing
- `python -m compileall -q .`


------
https://chatgpt.com/codex/tasks/task_e_6883aaccac7c8324b01792a8b5545d04